### PR TITLE
Add lightweight method of getting wandb data without postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A command-line utility for downloading and archiving Weights & Biases experiment data to local storage formats optimized for offline analysis. Stores to PostgreSQL db + Parquet files, supports incremental updates and selective data retrieval.
 
+> For shared context and onboarding steps, see the [Agent Guide](../dr_ref/docs/guides/AGENT_GUIDE_dr_wandb.md).
+
 ## Installation
 
 ```bash
@@ -105,4 +107,3 @@ The tool generates the following files in the output directory:
 - **runtime**: Elapsed time since run start
 - **wandb_metadata**: Platform logging metadata (JSONB)
 - **metrics**: All logged metrics and values (JSONB, flattened in Parquet export)
-

--- a/src/dr_wandb/__init__.py
+++ b/src/dr_wandb/__init__.py
@@ -1,2 +1,9 @@
-def hello() -> str:
-    return "Hello from dr-wandb!"
+"""dr_wandb public API."""
+
+from .fetch import fetch_project_runs, serialize_history_entry, serialize_run
+
+__all__ = [
+    "fetch_project_runs",
+    "serialize_history_entry",
+    "serialize_run",
+]

--- a/src/dr_wandb/fetch.py
+++ b/src/dr_wandb/fetch.py
@@ -1,0 +1,80 @@
+"""Lightweight WandB fetch utilities that avoid database storage."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import wandb
+
+from dr_wandb.history_entry_record import HistoryEntryRecord
+from dr_wandb.run_record import RunRecord
+from dr_wandb.utils import default_progress_callback
+
+ProgressFn = Callable[[int, int, str], None]
+
+
+def _iterate_runs(
+    entity: str,
+    project: str,
+    *,
+    runs_per_page: int,
+) -> Iterator[wandb.apis.public.Run]:
+    api = wandb.Api()
+    yield from api.runs(f"{entity}/{project}", per_page=runs_per_page)
+
+
+def serialize_run(run: wandb.apis.public.Run) -> dict[str, Any]:
+    """Convert a WandB run into a JSON-friendly dict."""
+
+    record = RunRecord.from_wandb_run(run)
+    return record.to_dict(include="all")
+
+
+def serialize_history_entry(
+    run: wandb.apis.public.Run, history_entry: dict[str, Any]
+) -> dict[str, Any]:
+    """Convert a raw history payload into a structured dict."""
+
+    record = HistoryEntryRecord.from_wandb_history(history_entry, run.id)
+    return {
+        "run_id": record.run_id,
+        "step": record.step,
+        "timestamp": record.timestamp,
+        "runtime": record.runtime,
+        "wandb_metadata": record.wandb_metadata,
+        "metrics": record.metrics,
+    }
+
+
+def fetch_project_runs(
+    entity: str,
+    project: str,
+    *,
+    runs_per_page: int = 500,
+    include_history: bool = True,
+    progress_callback: ProgressFn | None = None,
+) -> tuple[list[dict[str, Any]], list[list[dict[str, Any]]]]:
+    """Download runs (and optional history) without requiring Postgres."""
+
+    progress = progress_callback or default_progress_callback
+
+    runs: list[dict[str, Any]] = []
+    histories: list[list[dict[str, Any]]] = []
+
+    run_iter = list(_iterate_runs(entity, project, runs_per_page=runs_per_page))
+    total = len(run_iter)
+
+    for index, run in enumerate(run_iter, start=1):
+        runs.append(serialize_run(run))
+        if include_history:
+            history_payloads = [
+                serialize_history_entry(run, entry) for entry in run.scan_history()
+            ]
+            histories.append(history_payloads)
+        progress(index, total, run.name)
+
+    if not include_history:
+        histories = []
+
+    return runs, histories

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from dr_wandb.fetch import fetch_project_runs
+
+
+def test_fetch_project_runs_with_history(mock_wandb_run, sample_history_entries):
+    mock_wandb_run.scan_history.return_value = sample_history_entries
+
+    with patch("dr_wandb.fetch._iterate_runs", return_value=iter([mock_wandb_run])):
+        runs, histories = fetch_project_runs(
+            "test_entity",
+            "test_project",
+            runs_per_page=50,
+            include_history=True,
+            progress_callback=lambda *args: None,
+        )
+
+    assert len(runs) == 1
+    run_payload = runs[0]
+    assert run_payload["run_id"] == mock_wandb_run.id
+    assert run_payload["config"]["learning_rate"] == 0.001
+
+    assert len(histories) == 1
+    history_entries = histories[0]
+    assert history_entries[0]["run_id"] == mock_wandb_run.id
+    assert history_entries[0]["metrics"]["loss"] == sample_history_entries[0]["loss"]
+    assert history_entries[0]["timestamp"].isoformat().startswith("2024-01-")
+
+
+def test_fetch_project_runs_without_history(mock_wandb_run):
+    progress_calls: list[tuple[int, int, str]] = []
+
+    def progress(idx: int, total: int, name: str) -> None:
+        progress_calls.append((idx, total, name))
+
+    with patch("dr_wandb.fetch._iterate_runs", return_value=iter([mock_wandb_run])):
+        runs, histories = fetch_project_runs(
+            "test_entity",
+            "test_project",
+            include_history=False,
+            progress_callback=progress,
+        )
+
+    assert len(runs) == 1
+    assert runs[0]["run_id"] == mock_wandb_run.id
+    assert histories == []
+    assert progress_calls == [(1, 1, mock_wandb_run.name)]
+


### PR DESCRIPTION
### TL;DR

Added lightweight fetch utilities to download W&B experiment data without requiring PostgreSQL storage.

### What changed?

- Added a new `fetch.py` module with functions to download W&B runs and history data
- Exposed public API functions in `__init__.py`: `fetch_project_runs`, `serialize_history_entry`, and `serialize_run`
- Added unit tests for the new fetch functionality
- Updated README with a link to the Agent Guide for onboarding context

### How to test?

```python
from dr_wandb import fetch_project_runs

# Download runs and their history data
runs, histories = fetch_project_runs(
    entity="your-entity",
    project="your-project",
    include_history=True
)

# Process the downloaded data
for run, history in zip(runs, histories):
    print(f"Run {run['name']} has {len(history)} history entries")
```

### Why make this change?

This change provides a lightweight way to fetch W&B experiment data without requiring a PostgreSQL database. This makes it easier to use the library for quick data analysis tasks or in environments where setting up a database is not feasible. The exposed functions allow users to download run metadata and history entries in a structured format that can be easily processed or saved to other formats.