### PR TITLE
bump the version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dr-wandb"
-version = "0.1.0"
+version = "0.1.1"
 description = "Interact with wandb from python"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -89,7 +89,7 @@ wheels = [
 
 [[package]]
 name = "dr-wandb"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "pandas" },


### PR DESCRIPTION
### TL;DR

Bump version from 0.1.0 to 0.1.1

### What changed?

Updated the package version in both `pyproject.toml` and `uv.lock` files from 0.1.0 to 0.1.1.

### How to test?

1. Verify that the version number is correctly updated in both files
2. Build the package and confirm the new version is reflected in the built package

### Why make this change?

This version bump is needed to release a new version of the package with recent changes that have been made since the 0.1.0 release.