### PR TITLE
Add raw run record dict loader and narrow run metadata access

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,37 @@ summary = engine.export_project(
 print(summary.run_count, summary.history_count)
 ```
 
+### Loading extracted run metadata
+
+Use the loader functions in `dr_wandb.run_metadata` when reading `runs_raw.jsonl` exports back in. Both loaders return only the latest raw snapshot per `run_id`, ordered by `createdAt` descending.
+
+```python
+from pathlib import Path
+
+from dr_wandb.run_metadata import (
+    load_canonical_run_metadata,
+    load_raw_run_record_dicts,
+)
+
+data_root = Path("./data")
+
+canonical_runs = load_canonical_run_metadata(
+    export_name="moe_runs",
+    data_root=data_root,
+)
+
+raw_run_dicts = load_raw_run_record_dicts(
+    export_name="moe_runs",
+    data_root=data_root,
+)
+```
+
+Choose the loader based on the shape you want:
+- `load_canonical_run_metadata(...)` returns `CanonicalRunMetadata` models with promoted fields like `name`, `config`, `summaryMetrics`, and `historyKeys`.
+- `load_raw_run_record_dicts(...)` returns `RawRunRecord`-shaped dictionaries with the original outer record fields: `run_id`, `entity`, `project`, `exported_at`, `raw_run_hash`, and `raw_run`.
+
+These are the supported read paths for run metadata exports. They intentionally deduplicate multiple raw rows for the same run and should be preferred over line-by-line access to `runs_raw.jsonl`.
+
 ## Core concepts
 
 ### `SyncPolicy`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dr-wandb"
-version = "1.1.0"
+version = "1.1.1"
 description = "Policy-driven sync and export toolkit for W&B runs"
 readme = "README.md"
 license = "MIT"

--- a/src/dr_wandb/run_metadata.py
+++ b/src/dr_wandb/run_metadata.py
@@ -221,7 +221,7 @@ def resolve_runs_raw_path(*, export_name: str, data_root: Path) -> Path:
     return resolve_raw_extract_profile_paths(profile).runs_raw_path
 
 
-def iter_raw_run_records(*, export_name: str, data_root: Path) -> Iterator[RawRunRecord]:
+def _iter_raw_run_records(*, export_name: str, data_root: Path) -> Iterator[RawRunRecord]:
     runs_raw_path = resolve_runs_raw_path(export_name=export_name, data_root=data_root)
     if not runs_raw_path.exists():
         raise FileNotFoundError(f"Missing raw extract file: {runs_raw_path}")
@@ -249,23 +249,45 @@ def load_canonical_run_metadata(
     export_name: str,
     data_root: Path,
 ) -> list[CanonicalRunMetadata]:
+    raw_records = _load_latest_raw_run_records(
+        export_name=export_name,
+        data_root=data_root,
+    )
+    return [
+        CanonicalRunMetadata.from_raw_run_record(record) for record in raw_records
+    ]
+
+
+def load_raw_run_record_dicts(
+    *,
+    export_name: str,
+    data_root: Path,
+) -> list[dict[str, Any]]:
+    raw_records = _load_latest_raw_run_records(
+        export_name=export_name,
+        data_root=data_root,
+    )
+    return [record.model_dump(mode="python") for record in raw_records]
+
+
+def _load_latest_raw_run_records(
+    *,
+    export_name: str,
+    data_root: Path,
+) -> list[RawRunRecord]:
     latest_by_run_id: dict[str, RawRunRecord] = {}
-    for record in iter_raw_run_records(export_name=export_name, data_root=data_root):
+    for record in _iter_raw_run_records(export_name=export_name, data_root=data_root):
         current = latest_by_run_id.get(record.run_id)
         if current is None or _record_sort_key(record) > _record_sort_key(current):
             latest_by_run_id[record.run_id] = record
 
-    canonical_runs = [
-        CanonicalRunMetadata.from_raw_run_record(record)
-        for record in latest_by_run_id.values()
-    ]
-    canonical_runs = sorted(canonical_runs, key=lambda record: record.run_id)
-    canonical_runs = sorted(
-        canonical_runs,
-        key=lambda record: record.createdAt or "",
+    raw_records = sorted(latest_by_run_id.values(), key=lambda record: record.run_id)
+    raw_records = sorted(
+        raw_records,
+        key=lambda record: _coerce_str(record.raw_run.get("createdAt")) or "",
         reverse=True,
     )
-    return canonical_runs
+    return raw_records
 
 
 def _record_sort_key(record: RawRunRecord) -> tuple[str, str]:

--- a/tests/test_run_metadata.py
+++ b/tests/test_run_metadata.py
@@ -12,8 +12,8 @@ from dr_wandb.run_metadata import (
     ParsedHistoryKeys,
     ParsedSummaryMetrics,
     UnparsedHistoryField,
-    iter_raw_run_records,
     load_canonical_run_metadata,
+    load_raw_run_record_dicts,
     resolve_runs_raw_path,
 )
 
@@ -283,10 +283,89 @@ def test_load_canonical_run_metadata_uses_hash_as_tie_breaker(tmp_path: Path):
     assert records[0].name == "newer"
 
 
-def test_iter_raw_run_records_raises_clear_error_on_bad_json(tmp_path: Path):
+def test_load_raw_run_record_dicts_keeps_latest_record_per_run_id(tmp_path: Path):
+    runs_raw_path = tmp_path / "wandb_export" / "wandb_raw_extract" / "runs_raw.jsonl"
+    _write_raw_records(
+        runs_raw_path,
+        [
+            {
+                "run_id": "run-1",
+                "entity": "entity",
+                "project": "project",
+                "exported_at": "2026-03-11T10:00:00+00:00",
+                "raw_run_hash": "hash-a",
+                "raw_run": {
+                    "name": "older",
+                    "createdAt": "2026-03-09T10:00:00+00:00",
+                },
+            },
+            {
+                "run_id": "run-1",
+                "entity": "entity",
+                "project": "project",
+                "exported_at": "2026-03-11T11:00:00+00:00",
+                "raw_run_hash": "hash-b",
+                "raw_run": {
+                    "displayName": "newer",
+                    "createdAt": "2026-03-09T10:00:00+00:00",
+                },
+            },
+            {
+                "run_id": "run-2",
+                "entity": "entity",
+                "project": "project",
+                "exported_at": "2026-03-11T09:00:00+00:00",
+                "raw_run_hash": "hash-c",
+                "raw_run": {
+                    "name": "second",
+                    "createdAt": "2026-03-10T10:00:00+00:00",
+                },
+            },
+        ],
+    )
+
+    records = load_raw_run_record_dicts(export_name="wandb_export", data_root=tmp_path)
+
+    assert [record["run_id"] for record in records] == ["run-2", "run-1"]
+    assert records[1]["raw_run"]["displayName"] == "newer"
+    assert records[1]["raw_run_hash"] == "hash-b"
+
+
+def test_load_raw_run_record_dicts_uses_hash_as_tie_breaker(tmp_path: Path):
+    runs_raw_path = tmp_path / "wandb_export" / "wandb_raw_extract" / "runs_raw.jsonl"
+    _write_raw_records(
+        runs_raw_path,
+        [
+            {
+                "run_id": "run-1",
+                "entity": "entity",
+                "project": "project",
+                "exported_at": "2026-03-11T10:00:00+00:00",
+                "raw_run_hash": "aaa",
+                "raw_run": {"name": "older"},
+            },
+            {
+                "run_id": "run-1",
+                "entity": "entity",
+                "project": "project",
+                "exported_at": "2026-03-11T10:00:00+00:00",
+                "raw_run_hash": "bbb",
+                "raw_run": {"name": "newer"},
+            },
+        ],
+    )
+
+    records = load_raw_run_record_dicts(export_name="wandb_export", data_root=tmp_path)
+
+    assert len(records) == 1
+    assert records[0]["raw_run"]["name"] == "newer"
+    assert records[0]["raw_run_hash"] == "bbb"
+
+
+def test_load_raw_run_record_dicts_raises_clear_error_on_bad_json(tmp_path: Path):
     runs_raw_path = tmp_path / "wandb_export" / "wandb_raw_extract" / "runs_raw.jsonl"
     runs_raw_path.parent.mkdir(parents=True, exist_ok=True)
     runs_raw_path.write_text("{bad json}\n", encoding="utf-8")
 
     with pytest.raises(ValueError, match="line 1"):
-        list(iter_raw_run_records(export_name="wandb_export", data_root=tmp_path))
+        load_raw_run_record_dicts(export_name="wandb_export", data_root=tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ wheels = [
 
 [[package]]
 name = "dr-wandb"
-version = "1.0.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "pandas" },


### PR DESCRIPTION
## Summary
- add `load_raw_run_record_dicts(...)` as the public loader for latest-per-run raw metadata
- keep the raw row iterator internal so callers do not accidentally read every historical snapshot
- document the two supported loader functions and bump the package version

## Testing
- `uv run pytest tests/test_run_metadata.py`
- loaded real data from `../ml-moe/data/moe_runs/wandb_raw_extract/runs_raw.jsonl`
- verified `load_raw_run_record_dicts(...)` returns the same run selection and ordering as `load_canonical_run_metadata(...)`
