### PR TITLE
Add CLI progress logging to wandb-export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.2
+
+- Added CLI progress logging so `wandb-export` reports the first processed
+  run and then each additional 5% completion bucket during exports.
+
 ## 3.0.1
 
 - Updated `dr-wandb` to depend on `dr-ds==0.1.4`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added CLI progress logging so `wandb-export` reports the first processed
   run and then each additional 5% completion bucket during exports.
+- Added `DR_WANDB_LOG_LEVEL` so CLI log verbosity can be overridden for batch
+  runs and CI without changing code.
 
 ## 3.0.1
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ History selection rules to rely on:
   underlying W&B API call
 - `--max-records` trims the final result to the most recent rows after scanning
 
+The CLI logs progress to stderr by default. Set `DR_WANDB_LOG_LEVEL` to a
+standard Python logging level such as `DEBUG`, `INFO`, `WARNING`, `ERROR`, or
+`CRITICAL` to override that behavior for batch runs or CI. Invalid values fall
+back to `INFO`.
+
 ## Sync Semantics
 
 `dr-wandb` supports two sync modes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dr-wandb"
-version = "3.0.1"
+version = "3.0.2"
 description = "Unified export toolkit for Weights & Biases"
 readme = "README.md"
 license = "MIT"

--- a/src/dr_wandb/cli.py
+++ b/src/dr_wandb/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import typer
@@ -15,6 +16,17 @@ from dr_wandb.config import (
     SyncMode,
 )
 from dr_wandb.engine import ExportEngine
+
+
+def _configure_logging() -> None:
+    """Configure console logging for the public CLI without affecting other loggers."""
+    logger = logging.getLogger("dr_wandb")
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
 
 
 def export_command(
@@ -81,6 +93,7 @@ def export_command(
 
 def main() -> None:
     """Run the public `wandb-export` CLI."""
+    _configure_logging()
     typer.run(export_command)
 
 

--- a/src/dr_wandb/cli.py
+++ b/src/dr_wandb/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 
 import typer
@@ -18,6 +19,11 @@ from dr_wandb.config import (
 from dr_wandb.engine import ExportEngine
 
 
+def _resolve_log_level(level_name: str) -> int:
+    """Resolve a CLI log level name, falling back to INFO for invalid values."""
+    return logging.getLevelNamesMapping().get(level_name.upper(), logging.INFO)
+
+
 def _configure_logging() -> None:
     """Configure console logging for the public CLI without affecting other loggers."""
     logger = logging.getLogger("dr_wandb")
@@ -25,7 +31,9 @@ def _configure_logging() -> None:
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter("%(message)s"))
         logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(
+        _resolve_log_level(os.getenv("DR_WANDB_LOG_LEVEL", "INFO"))
+    )
     logger.propagate = False
 
 

--- a/src/dr_wandb/engine.py
+++ b/src/dr_wandb/engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +22,8 @@ from dr_wandb.selection import select_runs
 from dr_wandb.state import ExportState
 from dr_wandb.store import ExportStore
 from dr_wandb.wandb_run import RunSnapshot, WandbRun
+
+logger = logging.getLogger(__name__)
 
 
 class ExportEngine:
@@ -46,13 +49,27 @@ class ExportEngine:
         new_history_rows: list[HistoryRow] = []
 
         api = wandb.Api(timeout=self.request.timeout_seconds)
-        for raw_run in select_runs(api=api, request=self.request, state=state):
+        selected_runs = select_runs(api=api, request=self.request, state=state)
+        logger.info(
+            "Exporting %s run(s) for %s/%s into %s",
+            len(selected_runs),
+            self.request.entity,
+            self.request.project,
+            self.request.name,
+        )
+        last_logged_progress = 0
+        for index, raw_run in enumerate(selected_runs, start=1):
             self._process_run(
                 raw_run=raw_run,
                 state=state,
                 snapshots=snapshots,
                 new_history_rows=new_history_rows,
                 exported_at=exported_at,
+            )
+            last_logged_progress = self._log_progress(
+                processed_runs=index,
+                total_runs=len(selected_runs),
+                last_logged_progress=last_logged_progress,
             )
 
         sorted_snapshots = sorted(
@@ -103,6 +120,35 @@ class ExportEngine:
             history_count=len(history_rows),
             exported_at=exported_at,
         )
+
+    def _log_progress(
+        self,
+        *,
+        processed_runs: int,
+        total_runs: int,
+        last_logged_progress: int,
+    ) -> int:
+        """Log the first processed run and each additional 5% completion bucket."""
+        if total_runs <= 0:
+            return last_logged_progress
+
+        percent_complete = (processed_runs * 100) // total_runs
+        progress_bucket = min((percent_complete // 5) * 5, 100)
+        should_log = processed_runs == 1
+        if processed_runs == 1 and progress_bucket >= 5:
+            last_logged_progress = progress_bucket
+        elif progress_bucket >= 5 and progress_bucket > last_logged_progress:
+            should_log = True
+            last_logged_progress = progress_bucket
+
+        if should_log:
+            logger.info(
+                "Processed %s/%s runs (%s%% complete)",
+                processed_runs,
+                total_runs,
+                percent_complete,
+            )
+        return last_logged_progress
 
     def _load_initial_state(self, store: ExportStore) -> ExportState:
         """Load prior export state unless full reconcile explicitly resets it."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -8,7 +9,7 @@ import pytest
 import typer
 
 from dr_wandb import ExportMode, ExportRequest, ExportSummary, SyncMode
-from dr_wandb.cli import export_command
+from dr_wandb.cli import _configure_logging, _resolve_log_level, export_command
 
 
 class _FakeEngine:
@@ -92,3 +93,30 @@ def test_cli_rejects_history_flags_without_history_mode(
             max_step=None,
             max_records=None,
         )
+
+
+def test_resolve_log_level_falls_back_to_info_for_invalid_values() -> None:
+    assert _resolve_log_level("DEBUG") == logging.DEBUG
+    assert _resolve_log_level("not-a-level") == logging.INFO
+
+
+def test_configure_logging_reads_log_level_from_environment(
+    monkeypatch: Any,
+) -> None:
+    logger = logging.getLogger("dr_wandb")
+    original_level = logger.level
+    original_propagate = logger.propagate
+    original_handlers = list(logger.handlers)
+    try:
+        logger.handlers = []
+        monkeypatch.setenv("DR_WANDB_LOG_LEVEL", "DEBUG")
+
+        _configure_logging()
+
+        assert logger.level == logging.DEBUG
+        assert logger.propagate is False
+        assert len(logger.handlers) == 1
+    finally:
+        logger.handlers = original_handlers
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -147,3 +148,61 @@ def test_state_is_not_advanced_when_manifest_write_fails(
         "state.json must not be saved when artifact writes fail"
     )
     assert store.load_manifest() is None
+
+
+def test_export_logs_first_run_and_each_five_percent_bucket(
+    tmp_path: Path, install_fake_wandb_api, caplog: pytest.LogCaptureFixture
+) -> None:
+    install_fake_wandb_api(
+        [
+            metadata_run(
+                f"run-{index}",
+                created_at="2024-01-01T00:00:00+00:00",
+                updated_at="2024-01-01T00:10:00+00:00",
+                state="finished",
+            )
+            for index in range(1, 41)
+        ]
+    )
+
+    caplog.set_level(logging.INFO, logger="dr_wandb.engine")
+
+    ExportEngine(
+        ExportRequest(
+            entity="ml-moe",
+            project="moe",
+            name="moe_runs",
+            data_root=tmp_path,
+            mode=ExportMode.METADATA,
+            sync_mode=SyncMode.FULL_RECONCILE,
+        )
+    ).export()
+
+    progress_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "Processed " in record.getMessage()
+    ]
+    assert progress_messages == [
+        "Processed 1/40 runs (2% complete)",
+        "Processed 2/40 runs (5% complete)",
+        "Processed 4/40 runs (10% complete)",
+        "Processed 6/40 runs (15% complete)",
+        "Processed 8/40 runs (20% complete)",
+        "Processed 10/40 runs (25% complete)",
+        "Processed 12/40 runs (30% complete)",
+        "Processed 14/40 runs (35% complete)",
+        "Processed 16/40 runs (40% complete)",
+        "Processed 18/40 runs (45% complete)",
+        "Processed 20/40 runs (50% complete)",
+        "Processed 22/40 runs (55% complete)",
+        "Processed 24/40 runs (60% complete)",
+        "Processed 26/40 runs (65% complete)",
+        "Processed 28/40 runs (70% complete)",
+        "Processed 30/40 runs (75% complete)",
+        "Processed 32/40 runs (80% complete)",
+        "Processed 34/40 runs (85% complete)",
+        "Processed 36/40 runs (90% complete)",
+        "Processed 38/40 runs (95% complete)",
+        "Processed 40/40 runs (100% complete)",
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "dr-wandb"
-version = "3.0.1"
+version = "3.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "dr-ds" },


### PR DESCRIPTION
Added progress logging to the `wandb-export` CLI that reports the first processed run and then each additional 5% completion bucket during exports.

**Changes**

- Added console logging configuration to the CLI module that sets up a simple formatter for the `dr_wandb` logger
- Enhanced the export engine to log progress messages showing processed runs and completion percentage
- Progress logging reports the first run processed, then logs at each 5% completion milestone
- Bumped version from 3.0.1 to 3.0.2